### PR TITLE
removing duplicate copies of mongo functions

### DIFF
--- a/pg_nosql_benchmark
+++ b/pg_nosql_benchmark
@@ -215,21 +215,6 @@ do
                                                     "${MONGOPASSWORD}" \
                                                     "${COLLECTION_NAME}"
                              )
-   drop_mongocollection "${MONGOHOST}"     \
-                        "${MONGOPORT}"     \
-                        "${MONGODBNAME}"   \
-                        "${MONGOUSER}"     \
-                        "${MONGOPASSWORD}" \
-                        "${COLLECTION_NAME}"
-
-   mongo_inserts_time[${indx}]=$(mongodb_inserts_benchmark "${MONGOHOST}"       \
-                                                           "${MONGOPORT}"       \
-                                                           "${MONGODBNAME}"     \
-                                                           "${MONGOUSER}"       \
-                                                           "${MONGOPASSWORD}"   \
-                                                           "${COLLECTION_NAME}" \
-                                                            "${MONGO_INSERTS}"
-                                )
 
    drop_mongocollection "${MONGOHOST}"     \
                         "${MONGOPORT}"     \


### PR DESCRIPTION
Removed the duplicate call of drop_mongocollection and mongodb_inserts_benchmark. Since, its a kind of bug fix. 
